### PR TITLE
Fix logo not rendering in firefox

### DIFF
--- a/.storybook/Logo.js
+++ b/.storybook/Logo.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import {RequestQRCode} from '../index'
+
+class Logo extends React.Component {
+  state = {
+    hideLogo: false,
+  }
+
+  render() {
+    return (
+      <div>
+        <input
+          type="checkbox"
+          checked={this.state.hideLogo}
+          onChange={() => this.setState({hideLogo: !this.state.hideLogo})}
+        />
+        <label>Hide center logo</label>
+        <br />
+        <RequestQRCode requestData={this.props.requestData} hideLogo={this.state.hideLogo} />
+      </div>
+    )
+  }
+}
+
+export {Logo}

--- a/.storybook/ShareQRCode.js
+++ b/.storybook/ShareQRCode.js
@@ -2,6 +2,7 @@ import React from 'react'
 import {storiesOf} from '@storybook/react'
 
 import {RequestQRCode, Action} from '../index'
+import {Logo} from './Logo'
 import {Manager} from './Manager'
 
 const defaultData = {
@@ -18,5 +19,6 @@ const defaultData = {
 storiesOf('RequestQRCode', module)
   .add('Default', () => <RequestQRCode requestData={defaultData} />)
   .add('Colors', () => <RequestQRCode requestData={defaultData} bgColor={'#EBF0F1'} fgColor={'#3C3C3D'} />)
+  .add('Logo', () => <Logo requestData={defaultData} />)
   .add('Size', () => <RequestQRCode requestData={defaultData} size={300} />)
   .add('Managed', () => <Manager requestData={defaultData} />)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloomprotocol/share-kit",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "Easily allow your users to share their verified personal information directly with your application by scanning a QR code.",
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@bloomprotocol/attestations-lib": "^0.4.3",
-    "@types/qrcode.react": "^0.8.1",
     "@types/react": "^16.4.13",
     "@types/react-dom": "^16.0.7",
     "react": "^16.4.2",

--- a/src/BloomLogo.ts
+++ b/src/BloomLogo.ts
@@ -56,6 +56,8 @@ class BloomLogo {
       },
       config || {}
     )
+    defaultedConfig.fgColor = encodeURIComponent(defaultedConfig.fgColor)
+    defaultedConfig.bgColor = encodeURIComponent(defaultedConfig.bgColor)
 
     return `data:image/svg+xml;utf8,${logoWithColors(defaultedConfig)}`
   }


### PR DESCRIPTION
**This PR**
- Fixes an issue where Firefox wasn't rendering the logo of our QR code due to the `#` in our `fgColor` and `bgColor` properties not parsing correctly. This has been fixed by running each value through [`encodeURIComponent`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent).
- Removes unused dependency found in package.json
- Added story demonstrating hide/show of logo
- Bumps version from 2.0.0 to 2.0.1