### PR TITLE
Add latest spec types and `verifyOffChainDataIntegrity`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This is the shape of the object that will be POSTed to the provided URL
 | ---------- | ----------------------------------------------------------------------- | -------------- |
 | bloom_id   | The user's BloomID                                                      | `number`       |
 | token      | Unique string to identify this data request                             | `string`       |
-| signature  | Request body signed by the Bloom app wallet                             | `string`       |
+| signature  | Signature of `packedData` by the user with their mnemonic.              | `string`       |
 | data       | Array of VerifiedData objects                                           | `VerifiedData` |
 | packedData | Hex string representation of the `data` property being keccak256 hashed | `string`       |
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Format of proof object used to perform merkle proof
 The endpoint specified in the QR code should be configured to accept data in the format shown in [ResponseData](#responsedata).
 
 ```javascript
-  const shareKitUtil = require('@bloomprotocol/share-kit/src/util')
+  const shareKit = require('@bloomprotocol/share-kit')
   const ethUtil = require('ethereumjs-util')
 
   export const recoverHashSigner = (hash: Buffer, sig: string): string => {
@@ -262,7 +262,7 @@ The endpoint specified in the QR code should be configured to accept data in the
       const sortedData = parsedData.map(d => sortObject(d))
 
       // Verify off chain data integrity
-      if (!sortedData.every(d => shareKitUtil.verifyOffChainDataIntegrity(d).length === 0)) {
+      if (!sortedData.every(d => shareKit.util.verifyOffChainDataIntegrity(d).length === 0)) {
         throw Error('Unable to verify the layer2Hash, attester address, and merkle proof with the provided data.')
       }
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ This is the shape of the object that will be POSTed to the provided URL
 
 | Name       | Description                                                             | Type           |
 | ---------- | ----------------------------------------------------------------------- | -------------- |
-| bloom_id   | The user's BloomID                                                      | `number`       |
+| subject    | The Ethereum address of the user sharing their data                     | `string`       |
 | token      | Unique string to identify this data request                             | `string`       |
 | signature  | Signature of `packedData` by the user with their mnemonic.              | `string`       |
 | data       | Array of VerifiedData objects                                           | `VerifiedData` |
@@ -236,8 +236,8 @@ The endpoint specified in the QR code should be configured to accept data in the
 
   app.post('/api/receiveData', async (req, res) => {
     try {
-      if (typeof req.body.bloom_id !== 'number') {
-        throw Error('Missing expected `bloom_id` of type `number` field in request.')
+      if (typeof req.body.subject !== 'string') {
+        throw Error('Missing expected `subject` of type `string` field in request.')
       }
       if (!(req.body.data instanceof Array)) {
         throw Error(

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import {generateRequestQRCode} from './src/generateRequestQRCode'
 import {createRequestQRCode, updateRequestQRCode, removeRequestQRCode} from './src/manageRequestQRCode'
 import {RequestQRCode} from './src/RequestQRCode'
-import {Action, RequestData, Options, NonceData, Nonces, ResponseData} from './src/types'
+import {Action, RequestData, Options, ResponseData} from './src/types'
 import {BloomLogo} from './src/BloomLogo'
 import * as util from './src/util'
 
@@ -15,8 +15,6 @@ export {
   RequestData,
   BloomLogo,
   Options,
-  NonceData,
-  Nonces,
   ResponseData,
   util,
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloomprotocol/share-kit",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "Easily allow your users to share their verified personal information directly with your application by scanning a QR code.",
@@ -25,7 +25,7 @@
     "storybook": "start-storybook -p 9001 -c .storybook"
   },
   "dependencies": {
-    "@bloomprotocol/attestations-lib": "^0.4.3",
+    "@bloomprotocol/attestations-lib": "^3.0.2",
     "@types/react": "^16.4.13",
     "@types/react-dom": "^16.0.7",
     "qr.js": "0.0.0",

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,7 +82,7 @@ interface IVerifiedData {
   proof: IProofShare[]
 
   /**
-   * Network on which the tx can be found
+   * The Ethereum network name on which the tx can be found
    */
   stage: 'mainnet' | 'rinkeby' | 'local'
 
@@ -92,7 +92,7 @@ interface IVerifiedData {
   target: HashingLogic.IDataNode
 
   /**
-   * Etherum address of the attester that performed the attestation
+   * Ethereum address of the attester that performed the attestation
    */
   attester: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,9 +99,9 @@ interface IVerifiedData {
 
 type ResponseData = {
   /**
-   * The bloom id of the user sharing data via share-kit
+   * The Ethereum address of the user sharing their data
    */
-  bloom_id: number
+  subject: string
 
   /**
    * Data shared to the receiving endpoint requested by the share-kit QR code.

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,72 +1,77 @@
 import * as util from './util'
 import {IVerifiedData} from './types'
+import {HashingLogic} from '@bloomprotocol/attestations-lib'
+import {IBloomMerkleTreeComponents} from '@bloomprotocol/attestations-lib/dist/src/HashingLogic'
 
-const mockData: IVerifiedData[] = [
-  {
-    tx: '0xe1f7b9603bd8d71927b9aabf88be14342964b4f4abc673a5e0f8dcbbd7c610e8',
-    stage: 'mainnet',
-    rootHash: '0xc13405b3de1d86d0e23ee749779dc4dc90166d1f74a4e76cf1cf84f3de15902f',
-    target: {
-      type: 'phone',
-      data: '+16195550587',
-      nonce: 'c3877038-79a9-477d-8037-9826032e6af5',
-      version: '1.0.0',
-    },
-    proof: [
+// Based on an mainnet email attestation and corresponding merkle tree components
+// https://etherscan.io/tx/0xf1d6b6b64e63737a4ef023fadc57e16793cfae5d931a3c301d14e375e54fabf6#decodetab
+test('Verifying layer2Hash, attester address, and merkle proof', () => {
+  // tslint:disable:max-line-length
+  const merkleTreeComponents: IBloomMerkleTreeComponents = {
+    rootHash: '0xfa0147ea749ba09f692162665de44b74801cfbeb16308aaf5788e87d0e1a09a1',
+    dataNodes: [
       {
-        position: 'right',
-        data: '0x662a74ce03d761ab066d0fc8306f474534fa5fdb087ad88baf067caefe1c026f',
-      },
-      {
-        position: 'right',
-        data: '0xdb7d23746b0e8cbb81762bdce521cee4abdd4232bd63f017d136f24a751d0a5b',
-      },
-    ],
-  },
-  {
-    tx: '0xe1f7b9603bd8d71927b9aabf88be14342964b4f4abc673a5e0f8dcbbd7c610e8',
-    stage: 'mainnet',
-    rootHash: '0xc13405b3de1d86d0e23ee749779dc4dc90166d1f74a4e76cf1cf84f3de15902f',
-    target: {
-      type: 'email',
-      data: 'test@bloom.co',
-      nonce: 'b3877038-79a9-477d-8037-9826032e6af4',
-      version: '1.0.0',
-    },
-    proof: [
-      {
-        position: 'left',
-        data: '0x2b81050468ea28d94e5db2ee6ae59e3cf03ab6f2da8c5f79c10e4d982af86844',
+        attestationNode: {
+          aux: '0x480f7971777eda1e6e6804f35435f5ae163623bf1404bda8f1018600f89d757f',
+          data: {
+            data: 'eddiehedges@gmail.com',
+            nonce: '5ee82099c52e30dc801131e12972fff1b8f90230dd268b04665c7385d959984b',
+            version: '2.0.0',
+          },
+          link: {
+            local: '0xdb81eabcbd65153a64b8c0e843e822c9c1f64bfbe5bf2481734a73288798b1b0',
+            global: '0x97e9ad0b20ba0f0528efef244c4fe6ef11f5a6b0c7b2667064080cd6d81ca5ca',
+            dataHash: '0xfd6a015fccf1a4140a40b939fc8755841324e3b3cc09cf02d325fb378aa72cbf',
+            typeHash: '0xb98d14777c16823502b7c962bf576b00b6f9f23d12c2c8a3bc11699a2dcfe8da',
+          },
+          type: {
+            type: 'email',
+            nonce: 'fe11a2cb674207c0120e0058de3f5c60935ffa0abbb62c22c439ffa07c409022',
+            provider: 'Bloom',
+          },
+        },
+        signedAttestation:
+          '0x4181089dad636fd35985e77a29c9b634bdf23254336bba6507ea0e2d75959bc71edb5c9265e91eeaf274ba1c7f992f4e802125ce02b02203e11704243f49235b1c',
       },
     ],
-  },
-  {
-    tx: '0xe1f7b9603bd8d71927b9aabf88be14342964b4f4abc673a5e0f8dcbbd7c610e8',
-    stage: 'mainnet',
-    rootHash: '0xc13405b3de1d86d0e23ee749779dc4dc90166d1f74a4e76cf1cf84f3de15902f',
-    target: {
-      type: 'full-name',
-      data: 'John Bloom',
-      nonce: 'a3877038-79a9-477d-8037-9826032e6af0',
-      version: '1.0.0',
-    },
-    proof: [
-      {
-        position: 'left',
-        data: '0x07b51789d6bbe5cb084c502b03168adafbbb58ad5fff2af9f612b2b9cf54c31f',
-      },
-      {
-        position: 'right',
-        data: '0xdb7d23746b0e8cbb81762bdce521cee4abdd4232bd63f017d136f24a751d0a5b',
-      },
+    layer2Hash: '0x6cca42a6266f647be85fba506fccc9925a995fee74fe08fe619c6a37cfbcb9ca',
+    checksumSig:
+      '0x068d4348cad148f1b768b464becddbbe5b9643782545ba91bd46de9fc0dd769f0dae8d36e0eb00913055d5bc9c6fcb4b0be733cb36046fd0da0ea5ecf5fc8f031b',
+    paddingNodes: [
+      '0xf16c379434bef8f2fdacc79d507d278e3bacc2288d6b6897082e4c127b41ffe7',
+      '0xc15e45159839629cb3006f1ad182c970f1279fa8faf7fff91fd967d895d320e0',
+      '0x10dca4bf55edf10c4e743cd0e0fbbfc3a893e5432577187f1ee40bd17c3e4d71',
+      '0x8be5191e55e938cca9bfdafdd8497b3fee10dc67cf5aec06a21cd5d3215477eb',
+      '0x31b5a691edcba21a4fda7cc9383f954f129a4c5e97fe5c038e9f4c6e93cda22e',
+      '0x871926ac31ac3314d5dc7dff83ab392d05549e1df4e40215064dc2acb7730239',
+      '0xf8da5b084a9c4b9cf1b2ed684d80a7d96f34ce2c3a0b5d1c3d9c602e96672102',
+      '0x39457c0604b3ad8fcd1f44a9a97f5f8c975c1dec847a2720b98a5a7f6a1bec97',
+      '0x5f03c7ac52ef6ba176278a1ad1faae5b82b431047a77b614739281b30e33be89',
+      '0x596e55f7ec195a7884bdd0b7ebb6a038796206a57f1062d4a97db5a55547e058',
+      '0x0feeab588ac8bcab0801c26a2821c4e66a9d1f4613629ddff8dd73da40278256',
+      '0xe45ee67ff362cec3c5a43df463f3e119b463151d571e4136621f74c0352336bc',
+      '0xc6783a9df936c58514d5189dba82698f8cd21ca83392f91ec1463851caa3880a',
+      '0x5c0fe232b0ab54bade933e074bb689b7751be2a6451dbba7f0eaad5cc9d68ff0',
     ],
-  },
-]
+    rootHashNonce: '0xa6a7d2b6d495bb12c0bb79d82bf5952ea8d5f14ceb948d5bf076b5b4c5f16517',
+    signedRootHash:
+      '0x434686f4ec981fc4e99c336c13c26a6f6d167918f9bbf04bb77ad85201bec74049c8516cc7683743eda44550160e4ae2c616ae9919c3360e5eb921c874579e491b',
+  }
+  // tslint:enable:max-line-length
 
-test('Verifying Merkle Proof', () => {
-  expect(
-    mockData.every(data => {
-      return util.verifyProof(data)
-    })
-  ).toBeTruthy()
+  const signedAttestationHash = HashingLogic.hashMessage(merkleTreeComponents.dataNodes[0].signedAttestation)
+  const merkleTree = HashingLogic.getMerkleTreeFromComponents(merkleTreeComponents)
+  const proof = util.formatProofForShare(merkleTree.getProof(util.toBuffer(signedAttestationHash)))
+  const emailShareData: IVerifiedData = {
+    tx: '0xf1d6b6b64e63737a4ef023fadc57e16793cfae5d931a3c301d14e375e54fabf6',
+    layer2Hash: merkleTreeComponents.layer2Hash,
+    rootHash: merkleTreeComponents.rootHash,
+    rootHashNonce: merkleTreeComponents.rootHashNonce,
+    proof,
+    stage: 'mainnet',
+    target: merkleTreeComponents.dataNodes[0],
+    attester: '0x40b469b080c4b034091448d0e59880d823b2fc18',
+  }
+
+  expect(util.verifyOffChainDataIntegrity(emailShareData)).toHaveLength(0)
 })

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,11 +1,19 @@
 import {IProofShare, IVerifiedData, IProof} from './types'
 import {HashingLogic} from '@bloomprotocol/attestations-lib'
 
+export const stripHexPrefix = (hexStr: string): string => {
+  if (hexStr.length < 2) return hexStr
+  if (hexStr.slice(0, 2) === '0x') return hexStr.slice(2)
+  return hexStr
+}
+
+export const toBuffer = (s: string) => new Buffer(stripHexPrefix(s), 'hex')
+
 export const formatProofForVerify = (proof: IProofShare[]): IProof[] => {
   return proof.map(node => {
     return {
       position: node.position,
-      data: new Buffer(stripHexPrefix(node.data), 'hex'),
+      data: toBuffer(node.data),
     }
   })
 }
@@ -19,18 +27,71 @@ export const formatProofForShare = (proof: IProof[]): IProofShare[] => {
   })
 }
 
-export const verifyProof = (data: IVerifiedData): boolean => {
-  const targetHash = HashingLogic.hashAttestation(data.target)
-  const proof = formatProofForVerify(data.proof)
-  return HashingLogic.verifyMerkleProof(
-    proof,
-    new Buffer(stripHexPrefix(targetHash), 'hex'),
-    new Buffer(stripHexPrefix(data.rootHash), 'hex')
-  )
+export type TVerificationError = {
+  key: string
+  error: string
 }
 
-const stripHexPrefix = (hexStr: string): string => {
-  if (hexStr.length < 2) return hexStr
-  if (hexStr.slice(0, 2) === '0x') return hexStr.slice(2)
-  return hexStr
+export const verifyProof = (data: IVerifiedData): boolean => {
+  const proof = formatProofForVerify(data.proof)
+  const targetNode = toBuffer(HashingLogic.hashMessage(data.target.signedAttestation))
+  const root = toBuffer(data.rootHash)
+
+  return HashingLogic.verifyMerkleProof(proof, targetNode, root)
+}
+
+/**
+ * Given an `IverifiedData` object this function will verify off chain data properties such as
+ * - Verifies that when hashing the rootHash and rootHash nonce the layer2Hash that's recovered
+ * matches what was provided
+ * - Confirms that the attester addresses provided matches the recovered address when recovering
+ * via `ecrecover` using the attestationNode and signature provided
+ * - Verifies the merkle proof using the root hash and target node (signed attestation)
+ *
+ * @param data Object of type `IverifiedData` declared in `types.ts`
+ * @return If all verifications succeed an empty array is returned, otherwise any verification
+ * issues are reported back as an array of `TVerificationError` objects.
+ */
+export const verifyOffChainDataIntegrity = (data: IVerifiedData): TVerificationError[] => {
+  const verificationErrors: TVerificationError[] = []
+
+  // confirm root hash becomes layer 2 hash - hash(rootHash, rootHashnonce)
+  const recoveredLayer2Hash = HashingLogic.hashMessage(
+    HashingLogic.orderedStringify({
+      rootHash: data.rootHash,
+      nonce: data.rootHashNonce,
+    })
+  )
+  if (data.layer2Hash !== recoveredLayer2Hash) {
+    verificationErrors.push({
+      key: 'layer2Hash',
+      error:
+        "The provided 'layer2Hash' doesn't match the value" +
+        " recovered for the given 'rootHash' and 'rootHashNonce'.",
+    })
+  }
+
+  // confirm attester signature of target node
+  const recoveredAttesterAddress = HashingLogic.recoverHashSigner(
+    HashingLogic.hashAttestationNode(data.target.attestationNode),
+    data.target.signedAttestation
+  )
+  if (data.attester !== recoveredAttesterAddress) {
+    verificationErrors.push({
+      key: 'attester',
+      error:
+        "The provided 'attester' doesn't match the value" +
+        " recovered for the target 'attestationNode' and 'signedAttestation'.",
+    })
+  }
+
+  // verify merkle proof
+  if (!verifyProof(data)) {
+    verificationErrors.push({
+      key: 'proof',
+      error: "The provided 'proof' is invalid for the given 'signedAttestation' and 'rootHash'.",
+    })
+  }
+
+  return verificationErrors
 }


### PR DESCRIPTION
Changeset:
- Upgrade `@bloomprotocol/attestations-lib` dependency from 0.4.3 to 3.02
- Remove `Nonces` and `NonceData` types
- Update various types to match the latest spec used in the Bloom dApp and protocol.
- Add a `reflect new `IVerifiedData` format  and an example of `verifyOffChainDataIntegrity`.` to util.ts, which verifies the integrity of the layer2Hash formation, the attester address, and the merkle proof.
- Update util.test.ts to use `verifyOffChainDataIntegrity`, which encompasses the merkle proof verification
- Update docs to reflect new `IVerifiedData` format  and an example of `verifyOffChainDataIntegrity`.