### PR TITLE
Bump version, add validateUntypedResponseData, fix jest logging

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,4 +6,7 @@ module.exports = {
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   setupFiles: ['jest-canvas-mock'],
+  // Added to get console.log statements to work
+  // More info: https://stackoverflow.com/a/51115643/1165441
+  verbose: false,
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloomprotocol/share-kit",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "Easily allow your users to share their verified personal information directly with your application.",

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -75,3 +75,41 @@ test('Verifying layer2Hash, attester address, and merkle proof', () => {
 
   expect(util.verifyOffChainDataIntegrity(emailShareData)).toHaveLength(0)
 })
+
+test('Verify ResponseData that is structured incorrectly does not validate.', async () => {
+  const options: util.IValidateResponseDataOptions = {validateOnChain: false}
+
+  const undefinedResponseData = await util.validateUntypedResponseData(undefined, options)
+  expect(undefinedResponseData.data).toHaveLength(0)
+  expect(undefinedResponseData.errors).toHaveLength(1)
+  expect(undefinedResponseData.errors.map(x => x.key)).toContain('missingResponseData')
+
+  const nullResponseData = await util.validateUntypedResponseData(null, options)
+  expect(nullResponseData.data).toHaveLength(0)
+  expect(nullResponseData.errors).toHaveLength(1)
+  expect(nullResponseData.errors.map(x => x.key)).toContain('missingResponseData')
+
+  const emptyObject = await util.validateUntypedResponseData({}, options)
+  expect(emptyObject.data).toHaveLength(0)
+  expect(emptyObject.errors).toHaveLength(5)
+  expect(emptyObject.errors.map(x => x.key)).toContain('ResponseData.token')
+  expect(emptyObject.errors.map(x => x.key)).toContain('ResponseData.subject')
+  expect(emptyObject.errors.map(x => x.key)).toContain('ResponseData.data')
+  expect(emptyObject.errors.map(x => x.key)).toContain('ResponseData.packedData')
+  expect(emptyObject.errors.map(x => x.key)).toContain('ResponseData.signature')
+
+  const badOptions = {validateOnChain: true}
+  const badOptionsValidate = await util.validateUntypedResponseData(
+    {
+      token: 'fake',
+      subject: '0x0',
+      data: [{}],
+      packedData: '0x0',
+      signature: '0x0',
+    },
+    badOptions
+  )
+  expect(badOptionsValidate.data).toHaveLength(0)
+  expect(badOptionsValidate.errors).toHaveLength(1)
+  expect(badOptionsValidate.errors.map(x => x.key)).toContain('invalidOptions')
+})

--- a/src/util.ts
+++ b/src/util.ts
@@ -339,38 +339,20 @@ export const validateUntypedResponseData = async (
 
   const errors: TVerificationError[] = []
 
-  if (isNullOrWhiteSpace(responseData.token)) {
-    errors.push({
-      key: 'ResponseData.token',
-      error: "Request body requires a non-whitespace 'token' property of type string.",
-    })
-  }
-
-  if (isNullOrWhiteSpace(responseData.subject)) {
-    errors.push({
-      key: 'ResponseData.subject',
-      error: "Request body requires a non-whitespace 'subject' property of type string.",
-    })
-  }
+  let fields: Array<keyof ResponseData> = ['token', 'subject', 'packedData', 'signature']
+  fields.forEach((x: keyof ResponseData) => {
+    if (isNullOrWhiteSpace(responseData[x])) {
+      errors.push({
+        key: `ResponseData.${x}`,
+        error: `Request body requires a non-whitespace '${x}' property of type string.`,
+      })
+    }
+  })
 
   if (!(responseData.data instanceof Array) || !responseData.data.length) {
     errors.push({
       key: 'ResponseData.data',
       error: "Request body requires a non-empty 'data' property of type Array.",
-    })
-  }
-
-  if (isNullOrWhiteSpace(responseData.packedData)) {
-    errors.push({
-      key: 'ResponseData.packedData',
-      error: "Request body requires a non-whitespace 'packedData' property of type string.",
-    })
-  }
-
-  if (isNullOrWhiteSpace(responseData.signature)) {
-    errors.push({
-      key: 'ResponseData.signature',
-      error: "Request body requires a non-whitespace 'signature' property of type string.",
     })
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -271,7 +271,15 @@ export const validateResponseData = async (
   options: IValidateResponseDataOptions
 ): Promise<IValidateResponseDataOutput> => {
   if (options.validateOnChain && isNullOrWhiteSpace(options.web3Provider)) {
-    throw new Error('Unable to `validateOnChain` without a `web3Provider`.')
+    return {
+      data: [],
+      errors: [
+        {
+          key: 'invalidOptions',
+          error: 'Unable to `validateOnChain` without a `web3Provider`.',
+        },
+      ],
+    }
   }
 
   const errors: TVerificationError[] = []
@@ -316,4 +324,60 @@ export const validateResponseData = async (
     errors: errors,
     data: consumableData,
   }
+}
+
+export const validateUntypedResponseData = async (
+  responseData: any,
+  options: IValidateResponseDataOptions
+): Promise<IValidateResponseDataOutput> => {
+  if (!responseData) {
+    return {
+      errors: [{key: 'missingResponseData', error: 'Failed to validate falsey responseData'}],
+      data: [],
+    }
+  }
+
+  const errors: TVerificationError[] = []
+
+  if (isNullOrWhiteSpace(responseData.token)) {
+    errors.push({
+      key: 'ResponseData.token',
+      error: "Request body requires a non-whitespace 'token' property of type string.",
+    })
+  }
+
+  if (isNullOrWhiteSpace(responseData.subject)) {
+    errors.push({
+      key: 'ResponseData.subject',
+      error: "Request body requires a non-whitespace 'subject' property of type string.",
+    })
+  }
+
+  if (!(responseData.data instanceof Array) || !responseData.data.length) {
+    errors.push({
+      key: 'ResponseData.data',
+      error: "Request body requires a non-empty 'data' property of type Array.",
+    })
+  }
+
+  if (isNullOrWhiteSpace(responseData.packedData)) {
+    errors.push({
+      key: 'ResponseData.packedData',
+      error: "Request body requires a non-whitespace 'packedData' property of type string.",
+    })
+  }
+
+  if (isNullOrWhiteSpace(responseData.signature)) {
+    errors.push({
+      key: 'ResponseData.signature',
+      error: "Request body requires a non-whitespace 'signature' property of type string.",
+    })
+  }
+
+  if (errors.length > 0) {
+    return {errors, data: []}
+  }
+
+  const typedResponseData: ResponseData = responseData
+  return await validateResponseData(typedResponseData, options)
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -338,8 +338,7 @@ export const validateUntypedResponseData = async (
   }
 
   const errors: TVerificationError[] = []
-
-  let fields: Array<keyof ResponseData> = ['token', 'subject', 'packedData', 'signature']
+  const fields: Array<keyof ResponseData> = ['token', 'subject', 'packedData', 'signature']
   fields.forEach((x: keyof ResponseData) => {
     if (isNullOrWhiteSpace(responseData[x])) {
       errors.push({


### PR DESCRIPTION
**Changes**
- Port validation that untyped object is structured like a `ResponseData` type from receive-kit and include it as an additional function (`validateUntypedResponseData`) export.
- Add test coverage for new function.
- This also fixes a weird issue with jest not outputting to console.log.