### PR TITLE
Replace append-query dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 7.2.1
+
+**Bug fixes**:
+
+- Replace `append-query` dependency with internal function
+  - Fixes `npm audit` warning
+
 ## 7.2.0
 
 **Improvements**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloomprotocol/share-kit",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2012,11 +2012,6 @@
         "loader-utils": "^1.2.3"
       }
     },
-    "@types/append-query": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/append-query/-/append-query-2.0.0.tgz",
-      "integrity": "sha512-0YlmQr+wOjsHrt4cXEWY2Ef8pLPyz4jTQqv/mSiGzdf+q0ZymH7VoI7kvmXV6T31JLvlQwGo2b3B9FgR+qn19g=="
-    },
     "@types/babel__core": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
@@ -2074,6 +2069,11 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
+    },
+    "@types/extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
@@ -2659,14 +2659,6 @@
       "resolved": "https://registry.npmjs.org/app-root-dir/-/app-root-dir-1.0.2.tgz",
       "integrity": "sha1-OBh+wt6nV3//Az/8sSFyaS/24Rg=",
       "dev": true
-    },
-    "append-query": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/append-query/-/append-query-2.0.1.tgz",
-      "integrity": "sha1-2ZallUw3RrAM7Xs2+h7i8CNkICU=",
-      "requires": {
-        "extend": "^1.3.0"
-      }
     },
     "aproba": {
       "version": "1.2.0",
@@ -6139,9 +6131,9 @@
       }
     },
     "extend": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
-      "integrity": "sha1-0VFvsP9WJNLr+RI+odrFoZlABPg="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -11375,8 +11367,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -14366,7 +14357,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -14375,8 +14365,7 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloomprotocol/share-kit",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "main": "dist/index.js",
   "module": "dist/share-kit.esm.js",
   "typings": "dist/index.d.ts",
@@ -24,12 +24,13 @@
   },
   "dependencies": {
     "@bloomprotocol/attestations-lib": "^5.0.0",
-    "@types/append-query": "^2.0.0",
     "@types/common-tags": "^1.8.0",
-    "append-query": "^2.0.1",
+    "@types/extend": "^3.0.1",
     "bowser": "^2.4.0",
     "common-tags": "^1.8.0",
-    "qr.js": "0.0.0"
+    "extend": "^3.0.2",
+    "qr.js": "0.0.0",
+    "url": "^0.11.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.4",

--- a/src/append.ts
+++ b/src/append.ts
@@ -1,0 +1,22 @@
+import extend from 'extend'
+
+const url = require('url')
+
+const appendQuery = (uri: string, queryToAppend: {[key: string]: string | null}) => {
+  const parts = url.parse(uri, true)
+  const parsedQuery = extend(true, {}, parts.query, queryToAppend)
+
+  const queryString = Object.keys(parsedQuery)
+    .map(key => {
+      const value = parsedQuery[key]
+      return value === null ? encodeURIComponent(key) : encodeURIComponent(key) + '=' + encodeURIComponent(value)
+    })
+    .join('&')
+
+  parts.query = null
+  parts.search = queryString ? '?' + queryString : null
+
+  return url.format(parts)
+}
+
+export {appendQuery}

--- a/src/renderRequestElement.ts
+++ b/src/renderRequestElement.ts
@@ -1,6 +1,6 @@
 import Bowser from 'bowser'
-import appendQuery from 'append-query'
 
+import {appendQuery} from './append'
 import {QROptions, ButtonOptions, RequestData, ShouldRenderButton, RequestElementResult} from './types'
 import {renderRequestButton} from './elements/renderRequestButton'
 import {renderRequestQRCode} from './elements/renderRequestQRCode'
@@ -24,7 +24,7 @@ const renderRequestElement = (config: {
   const shouldRenderButton = config.shouldRenderButton(Bowser.parse(window.navigator.userAgent))
 
   // Append a query parameter to inform the server how the data has been shared
-  config.requestData.url = appendQuery(config.requestData.url, `share-kit-from=${shouldRenderButton ? 'button' : 'qr'}`)
+  config.requestData.url = appendQuery(config.requestData.url, {'share-kit-from': `${shouldRenderButton ? 'button' : 'qr'}`})
 
   if (shouldRenderButton) {
     return renderRequestButton(config)

--- a/test/append.test.ts
+++ b/test/append.test.ts
@@ -1,0 +1,29 @@
+import {appendQuery} from '../src/append'
+
+test('should append query object to url', () => {
+  const result = appendQuery('http://example.com/', {foo: 'bar'})
+  const expected = 'http://example.com/?foo=bar'
+
+  expect(result).toEqual(expected)
+})
+
+test('should append query object to url with existing query', () => {
+  const result = appendQuery('http://example.com/?foo=bar', {baz: 'qux'})
+  const expected = 'http://example.com/?foo=bar&baz=qux'
+
+  expect(result).toEqual(expected)
+})
+
+test('should encode the params', () => {
+  const result = appendQuery('http://example.com/', {foo: '"bar"'})
+  const expected = 'http://example.com/?foo=%22bar%22'
+
+  expect(result).toEqual(expected)
+})
+
+test('appends just the key if value is null', () => {
+  const result = appendQuery('http://example.com/', {foo: null})
+  const expected = 'http://example.com/?foo'
+
+  expect(result).toEqual(expected)
+})


### PR DESCRIPTION
## Ultimate Problem
A dependency of `append-query` was giving an `npm audit` warning

## Solution
- Because `append-query` hasn't been updated in quite a while it's best to just re-create the functionality within the package